### PR TITLE
DB interface boilerplate

### DIFF
--- a/db/interface.py
+++ b/db/interface.py
@@ -1,0 +1,69 @@
+# -*- coding:utf-8 -*-
+
+from db.models import Payment, Detail
+
+
+class PaymentService(object):
+    """
+    Serves as an interface which takes requests from the front-end
+    and runs the corresponding actions in the database.
+    """
+
+    def __init__(self):
+        """
+        Initialize connection to database here.
+        """
+
+    def add_payment(self, payment_data):
+        """
+        Takes a dictionary of payment parameters and creates a new
+        payment item in the database using those parameters' data.
+
+        :param payment_data: <dict> a validated JSON payload that describes a new Payment object
+        """
+
+        raise NotImplementedError()
+
+    def remove_payment(self, payment_id=None, **kwargs):
+        """
+        Accepts an id or a variable number of keyword arguments
+        that could be used to identify a payment if the id is
+        not known.
+
+        :param payment_id: <int> the unique identifier of a payment to be removed
+        """
+
+        raise NotImplementedError()
+
+    def update_payment(self, payment_id, payment_replacement=None, **kwargs):
+        """
+        Uses the payment_id to find a specific payment item to update.
+        If the update is via a PUT request, wherein the new object overwrites
+        the old one completely, then new_payment should be supplied.
+        Else, for updates via PATCH requests, the fields found in **kwargs
+        will be used to overwrite the ones currently associated with the payment.
+
+        :param payment_id: <int> the unique identifier of a payment to be updated
+        :param payment_replacement: <dict> a complete payload that describes a new payload which replaces the old one
+        """
+
+        raise NotImplementedError()
+
+    def get_payments(self, payment_ids=None, payment_attributes=None):
+        """
+        Retrieves one or more payment items depending on the parameters
+        passed in:
+            - payment_ids, if present, will mean that the system should return
+              all payment items that correspond to those ids.  Note that a list witj
+              a single element is acceptable here.
+            - payment_attributes, if present, will mean to query the database
+              for all payment items that match the attributes.
+
+        If neither parameter is supplied, then all payment items are returned.
+
+        :param payment_ids: <list[int]> a list of one or more payments to be retrieved
+        :param payment_attributes: <dict> a collection of payment attributes to be used in
+                                   filtering for specific payments
+        """
+
+        raise NotImplementedError()

--- a/db/services.py
+++ b/db/services.py
@@ -24,27 +24,27 @@ class PaymentService(object):
 
         raise NotImplementedError()
 
-    def remove_payment(self, payment_id=None, **kwargs):
+    def remove_payment(self, payment_id=None):
         """
-        Accepts an id or a variable number of keyword arguments
-        that could be used to identify a payment if the id is
-        not known.
+        Remove the payment item corresponding to the payment_id, if
+        such a payment item exists.
 
         :param payment_id: <int> the unique identifier of a payment to be removed
         """
 
         raise NotImplementedError()
 
-    def update_payment(self, payment_id, payment_replacement=None, **kwargs):
+    def update_payment(self, payment_id, payment_replacement=None, payment_attributes=None):
         """
         Uses the payment_id to find a specific payment item to update.
         If the update is via a PUT request, wherein the new object overwrites
         the old one completely, then new_payment should be supplied.
-        Else, for updates via PATCH requests, the fields found in **kwargs
+        Else, for updates via PATCH requests, the fields found in payment_attributes
         will be used to overwrite the ones currently associated with the payment.
 
         :param payment_id: <int> the unique identifier of a payment to be updated
         :param payment_replacement: <dict> a complete payload that describes a new payload which replaces the old one
+        :param payment_attributes: <dict> a collection of new payment attribute values that will overwrite old ones
         """
 
         raise NotImplementedError()

--- a/payments.py
+++ b/payments.py
@@ -6,10 +6,10 @@ import re
 import time
 from flask import Flask, jsonify, request, make_response, Response, json, url_for
 
-from db.interface import PaymentService
+from db.service import PaymentService
 
 # Instantiate persistence service to be used in CRUD methods
-payments_db = PaymentService()
+payments_service = PaymentService()
 
 # Create Flask application
 app = Flask(__name__)

--- a/payments.py
+++ b/payments.py
@@ -6,6 +6,11 @@ import re
 import time
 from flask import Flask, jsonify, request, make_response, Response, json, url_for
 
+from db.interface import PaymentService
+
+# Instantiate persistence service to be used in CRUD methods
+payments_db = PaymentService()
+
 # Create Flask application
 app = Flask(__name__)
 #app.config['LOGGING_LEVEL'] = logging.INFO

--- a/payments.py
+++ b/payments.py
@@ -6,7 +6,7 @@ import re
 import time
 from flask import Flask, jsonify, request, make_response, Response, json, url_for
 
-from db.service import PaymentService
+from db.services import PaymentService
 
 # Instantiate persistence service to be used in CRUD methods
 payments_service = PaymentService()


### PR DESCRIPTION
This adds a boilerplate module which will be implemented in future tickets.  By having the module actually exist, it'll be possible to write imports and method calls in an IDE and have them be recognized - I figured this would be helpful.

**NOTE**
It is assumed that #101 will be merged *prior* to this PR, since the code assumes that there is a `models.py` defined in the `db` directory.