### PR TITLE
Refactor query payments

### DIFF
--- a/app/db/interface.py
+++ b/app/db/interface.py
@@ -24,11 +24,7 @@ class PaymentService(object):
         :param payment_data: <dict> a validated JSON payload that describes a new Payment object
         """
         p = Payment()
-        #try:
         p.deserialize(payment_data)
-        # this is not ideal, but can't get it working otherwise
-        #except Exception as e:
-        #    raise DataValidationError(e.message)
         self.db.session.add(p)
         self.db.session.commit()
         result = p.serialize()

--- a/app/db/interface.py
+++ b/app/db/interface.py
@@ -1,8 +1,10 @@
 # -*- coding:utf-8 -*-
 
-from app.db import app_db
-from models import Payment, Detail
+from sqlalchemy import exc
+
+from app.db.models import Payment, Detail
 #from app.error_handlers import DataValidationError
+from app.db import app_db
 
 class PaymentService(object):
     """
@@ -75,3 +77,28 @@ class PaymentService(object):
         """
 
         raise NotImplementedError()
+
+    def _query_payments(self, payment_attributes):
+        """
+        Returns all payment items that fulfill the attributes used to
+        filter from all payment items.
+
+        Note: this method assumes that the attributes are safe and have been validated.
+
+        :param parameter_attributes: <dict> a collection of Payment attributes to filter by
+        :return: <list[Payment]> a list of the Payment items returned by the query
+        """
+        try:
+            payments = self.db.session.query.filter_by(**payment_attributes)
+            return payments
+
+        except exc.SQLAlchemyError:
+            raise PaymentServiceQueryError('Could not retrieve payment items due to query error with given attributes')
+
+
+
+class PaymentServiceException(Exception):
+    """ Generic exception class for PaymentService. """
+
+class PaymentServiceQueryError(Exception):
+    """ Raised when an internal query fails. """

--- a/app/db/interface.py
+++ b/app/db/interface.py
@@ -2,7 +2,7 @@
 
 from app.db import app_db
 from models import Payment, Detail
-from app.error_handlers import DataValidationError
+#from app.error_handlers import DataValidationError
 
 class PaymentService(object):
     """
@@ -24,11 +24,11 @@ class PaymentService(object):
         :param payment_data: <dict> a validated JSON payload that describes a new Payment object
         """
         p = Payment()
-        try:
-            p.deserialize(payment_data)
+        #try:
+        p.deserialize(payment_data)
         # this is not ideal, but can't get it working otherwise
-        except Exception as e:
-            raise DataValidationError(e.message)
+        #except Exception as e:
+        #    raise DataValidationError(e.message)
         self.db.session.add(p)
         self.db.session.commit()
         result = p.serialize()

--- a/app/db/interface.py
+++ b/app/db/interface.py
@@ -5,6 +5,7 @@ from sqlalchemy import exc
 from app.db.models import Payment, Detail
 #from app.error_handlers import DataValidationError
 from app.db import app_db
+from app.db.models import Payment
 
 class PaymentService(object):
     """
@@ -89,12 +90,11 @@ class PaymentService(object):
         :return: <list[Payment]> a list of the Payment items returned by the query
         """
         try:
-            payments = self.db.session.query.filter_by(**payment_attributes)
+            payments = self.db.session.query(Payment).filter_by(**payment_attributes)
             return payments
 
         except exc.SQLAlchemyError:
             raise PaymentServiceQueryError('Could not retrieve payment items due to query error with given attributes')
-
 
 
 class PaymentServiceException(Exception):

--- a/app/db/interface.py
+++ b/app/db/interface.py
@@ -23,9 +23,12 @@ class PaymentService(object):
 
         :param payment_data: <dict> a validated JSON payload that describes a new Payment object
         """
-        #raise DataValidationError('Invalid payment: body of request contained bad or no data')
         p = Payment()
-        p.deserialize(payment_data)
+        try:
+            p.deserialize(payment_data)
+        # this is not ideal, but can't get it working otherwise
+        except Exception as e:
+            raise DataValidationError(e.message)
         self.db.session.add(p)
         self.db.session.commit()
         result = p.serialize()

--- a/app/db/interface.py
+++ b/app/db/interface.py
@@ -90,7 +90,8 @@ class PaymentService(object):
         :return: <list[Payment]> a list of the Payment items returned by the query
         """
         try:
-            payments = self.db.session.query(Payment).filter_by(**payment_attributes)
+            payment_query = self.db.session.query(Payment).filter_by(**payment_attributes)
+            payments = payment_query.all()
             return payments
 
         except exc.SQLAlchemyError:

--- a/app/db/interface.py
+++ b/app/db/interface.py
@@ -85,6 +85,9 @@ class PaymentService(object):
         filter from all payment items.
 
         Note: this method assumes that the attributes are safe and have been validated.
+        Also, the attributes passed in *must* be part of the Payment schema, since the
+        query below is for the Payment model.  Later on we should have a parameter that
+        indicates which model to use.
 
         :param parameter_attributes: <dict> a collection of Payment attributes to filter by
         :return: <list[Payment]> a list of the Payment items returned by the query

--- a/app/db/interface.py
+++ b/app/db/interface.py
@@ -1,5 +1,8 @@
 # -*- coding:utf-8 -*-
 
+from app.db import app_db
+from models import Payment, Detail
+from app.error_handlers import DataValidationError
 
 class PaymentService(object):
     """
@@ -11,6 +14,7 @@ class PaymentService(object):
         """
         Initialize connection to database here.
         """
+        self.db = app_db
 
     def add_payment(self, payment_data):
         """
@@ -19,8 +23,13 @@ class PaymentService(object):
 
         :param payment_data: <dict> a validated JSON payload that describes a new Payment object
         """
-
-        raise NotImplementedError()
+        #raise DataValidationError('Invalid payment: body of request contained bad or no data')
+        p = Payment()
+        p.deserialize(payment_data)
+        self.db.session.add(p)
+        self.db.session.commit()
+        result = p.serialize()
+        return result
 
     def remove_payment(self, payment_id=None, payment_attributes=None):
         """

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -2,7 +2,6 @@
 from flask import url_for
 from app.db import app_db
 from app.error_handlers import DataValidationError
-
 ######################################################################
 # Models
 ######################################################################
@@ -54,7 +53,6 @@ class Payment(app_db.Model):
             raise DataValidationError('Invalid payment: missing ' + e.args[0])
         except TypeError as e:
             raise DataValidationError('Invalid payment: body of request contained bad or no data')
-        #return self
 
 class Detail(app_db.Model):
     __tablename__ = 'detail'

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -2,6 +2,8 @@
 from flask import url_for
 from app.db import app_db
 from app.error_handlers import DataValidationError
+
+
 ######################################################################
 # Models
 ######################################################################

--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -20,9 +20,9 @@ def request_validation_error(e):
 def not_found(e):
     return make_response(jsonify(status=404, error='Not Found', message=e.description), status.HTTP_404_NOT_FOUND)
 
-@app.errorhandler(400)
-def bad_request(e):
-    return make_response(jsonify(status=400, error='Bad Request', message=e.message), status.HTTP_400_BAD_REQUEST)
+#@app.errorhandler(400)
+#def bad_request(e):
+#    return make_response(jsonify(status=400, error='Bad Request', message=e.message), status.HTTP_400_BAD_REQUEST)
 
 @app.errorhandler(405)
 def method_not_allowed(e):

--- a/app/error_handlers.py
+++ b/app/error_handlers.py
@@ -20,9 +20,9 @@ def request_validation_error(e):
 def not_found(e):
     return make_response(jsonify(status=404, error='Not Found', message=e.description), status.HTTP_404_NOT_FOUND)
 
-#@app.errorhandler(400)
-#def bad_request(e):
-#    return make_response(jsonify(status=400, error='Bad Request', message=e.message), status.HTTP_400_BAD_REQUEST)
+@app.errorhandler(400)
+def bad_request(e):
+    return make_response(jsonify(status=400, error='Bad Request', message=e.message), status.HTTP_400_BAD_REQUEST)
 
 @app.errorhandler(405)
 def method_not_allowed(e):

--- a/app/payments.py
+++ b/app/payments.py
@@ -117,7 +117,7 @@ def get_payments(id):
     except Exception:
         result = NOT_FOUND_ERROR_BODY
         # place the id into the {} in the error message string
-        result['error'].format(id)
+        result['error'] = result['error'].format(id)
         rc = HTTP_404_NOT_FOUND
 
     return make_response(jsonify(result), rc)

--- a/app/payments.py
+++ b/app/payments.py
@@ -123,35 +123,6 @@ def get_payments(id):
     return make_response(jsonify(result), rc)
 
 ######################################################################
-# RETRIEVE A PAYMENT ON QUERY
-######################################################################
-def query_payments():
-
-    q = request.query_string
-    key = re.search('\w*', q)
-    key = key.group(0)          
-    value = re.search('=\w*', q)
-    value = value.group(0)[1::]
-
-    list=[]
-    for p in payments:
-        if p.has_key(key):
-            if p[key] == value:
-                list.append(p)
-        else:
-            message = { 'error' : '%s is not a valid key' % key }
-            rc = HTTP_404_NOT_FOUND
-            return make_response(jsonify(message), rc)
-    
-    if len(list) > 0:
-        message = list
-        rc = HTTP_200_OK
-    else:
-        message = { 'error' : 'Payment with %s: %s was not found' % (key,value) }
-        rc = HTTP_404_NOT_FOUND
-    return make_response(jsonify(message), rc)
-
-######################################################################
 # UPDATE AN EXISTING PAYMENT
 ######################################################################
 @app.route('/payments/<int:id>', methods=['PUT'])

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -63,7 +63,8 @@ class TestErrorHandlers(unittest.TestCase):
     def test_crud_get_id_not_found(self):
         resp = self.app.get('payments/777')
         self.assertTrue(resp.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertTrue('777 was not found' in resp.data)
+        print resp.data
+        self.assertTrue(payments.NOT_FOUND_ERROR_BODY['error'].format(777) in resp.data)
 
     def test_crud_put_id_not_found(self):
         resp = self.app.put('payments/778')

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -63,7 +63,6 @@ class TestErrorHandlers(unittest.TestCase):
     def test_crud_get_id_not_found(self):
         resp = self.app.get('payments/777')
         self.assertTrue(resp.status_code, status.HTTP_404_NOT_FOUND)
-        print resp.data
         self.assertTrue(payments.NOT_FOUND_ERROR_BODY['error'].format(777) in resp.data)
 
     def test_crud_put_id_not_found(self):

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -56,6 +56,10 @@ QUERY_ATTRIBUTES = {
     'nickname': 'my paypal'
 }
 
+BAD_QUERY_ATTRIBUTES = {
+    'payment_type': 'Amateurcard'
+}
+
 class TestInterface(unittest.TestCase):
 
     def setUp(self):
@@ -198,7 +202,10 @@ class TestInterfaceFunctional(unittest.TestCase):
         result = ps._query_payments(QUERY_ATTRIBUTES)
         # in this case, PP_RETURN was the third item added, so its id should be 3, not 1
         PP_RETURN['payment_id'] = 3
-
         # should only be one result, so get the only element of the list
         assert result[0].serialize() == PP_RETURN
 
+    def test_unsuccessful_query(self):
+        # try querying for something that doesn't exist
+        result = ps._query_payments(BAD_QUERY_ATTRIBUTES)
+        assert result == []

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,0 +1,82 @@
+# Test cases can be run with either of the following:
+# python -m unittest discover
+# nosetests -v --rednose --nologcapture
+
+import unittest
+
+from app import payments
+from app.db import app_db
+from app.db.models import Payment, Detail
+from app.db.interface import PaymentService
+from app.error_handlers import DataValidationError
+
+CREDIT = {'nickname' : 'my credit', 'user_id' : 1, 'payment_type' : 'credit', 
+             'details' : {'user_name' : 'Jimmy Jones', 'card_number' : '1111222233334444',
+             'expires' : '01/2019', 'card_type' : 'Mastercard'}}
+
+DEBIT = {'nickname' : 'my debit', 'user_id' : 2, 'payment_type' : 'debit', 
+         'details' : {'user_name' : 'John Jameson', 'card_number' : '4444333322221111',
+         'expires' : '02/2020', 'card_type' : 'Visa'}}
+
+PAYPAL = {'nickname' : 'my paypal', 'user_id' : 2, 'payment_type' : 'paypal', 
+          'details' : {'user_name' : 'John Jameson', 'user_email' : 'jj@aol.com'}}
+
+#note 'nickname' is spelled wrong
+BAD_DATA = {'nicknam3' : 'my paypal', 'user_id' : 2, 'payment_type' : 'paypal', 
+            'details' : {'user_name' : 'John Jameson', 'user_email' : 'jj@aol.com'}}
+
+ps = PaymentService()
+
+class TestInterface(unittest.TestCase):
+
+    def setUp(self):
+        payments.app.debug = True
+        payments.app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://payments:payments@localhost:5432/test'
+        app_db.create_all()  # make our sqlalchemy tables
+        
+        data = CREDIT
+
+        payment = Payment()
+        payment.deserialize(data)
+        app_db.session.add(payment)
+        app_db.session.commit()
+        self.app = payments.app.test_client()
+
+    def tearDown(self):
+        app_db.session.remove()
+        app_db.drop_all()
+
+    def test_interface_add_card(self):
+        data = DEBIT
+        p2 = app_db.session.query(Payment).get(2)
+        self.assertEqual(p2, None)
+        ps.add_payment(data)
+        p2 = app_db.session.query(Payment).get(2)
+        d2 = p2.details
+        self.assertNotEqual(p2, None)
+        self.assertEqual(p2.nickname, 'my debit')
+        self.assertEqual(d2.user_name, 'John Jameson')
+
+    def test_interface_add_paypal(self):
+        data = PAYPAL
+        p2 = app_db.session.query(Payment).get(2)
+        self.assertEqual(p2, None)
+        ps.add_payment(data)
+        p2 = app_db.session.query(Payment).get(2)
+        d2 = p2.details
+        self.assertNotEqual(p2, None)
+        self.assertEqual(p2.nickname, 'my paypal')
+        self.assertEqual(d2.user_name, 'John Jameson')
+        self.assertEqual(d2.is_linked, True)
+
+    def test_interface_add_missing_details(self):
+        data = {'nickname' : 'my debit', 'user_id' : 2, 'payment_type' : 'debit'}
+        self.assertRaises(DataValidationError, ps.add_payment, data)
+
+    def test_interface_add_bad_data(self):
+        data = BAD_DATA
+        self.assertRaises(DataValidationError, ps.add_payment, data)
+
+    def test_interface_add_garbage(self):
+        garbage = 'afv@#(&@(#Z@#>X@C8rq rq34tr0q934r 9qr@(#*(@!$))'
+        self.assertRaises(DataValidationError, ps.add_payment, garbage)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -3,7 +3,7 @@
 # nosetests -v --rednose --nologcapture
 
 import unittest
-
+#from mock import patch
 from app import payments
 from app.db import app_db
 from app.db.models import Payment, Detail

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -7,7 +7,7 @@ import unittest, mock
 from app import payments
 from app.db import app_db
 from app.db.models import Payment, Detail
-from app.db.interface import PaymentService
+from app.db.interface import PaymentService, PaymentServiceQueryError
 from app.error_handlers import DataValidationError
 
 CC_DETAIL = {'user_name' : 'Jimmy Jones', 'card_number' : '1111222233334444',
@@ -152,3 +152,12 @@ class TestInterface(unittest.TestCase):
 
         mock_db.query(Payment).filter_by.assert_called_once_with(**QUERY_ATTRIBUTES)
         self.assertEqual(result, [DEBIT])
+
+    @mock.patch.object(app_db, 'session')
+    def test_interface_query_payments_error(self, mock_db):
+        mock_db.query(Payment).filter_by.side_effect = PaymentServiceQueryError
+
+        with self.assertRaises(PaymentServiceQueryError):
+            result = self.ps._query_payments(QUERY_ATTRIBUTES)
+        # also check that the mocked app_db was called appropriately
+        mock_db.query(Payment).filter_by.assert_called_once_with(**QUERY_ATTRIBUTES)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -42,7 +42,7 @@ CC_RETURN = dict(CREDIT, is_default=False, charge_history=0.0, payment_id=1)
 DC_RETURN = dict(DEBIT, is_default=False, charge_history=0.0, payment_id=2)
 
 QUERY_ATTRIBUTES = {
-    'user_id': 2,
+    'user_id': 1,
     'nickname': 'my paypal'
 }
 
@@ -191,7 +191,7 @@ class TestInterfaceFunctional(unittest.TestCase):
         # No mocking for this test since we want to test the method's ability to *actually* retrieve resources
         # the query attributes should match the CREDIT payment item
 
-        result = ps._query_payments(QUERY_ATTRIBUTES)
+        result = self.ps._query_payments(QUERY_ATTRIBUTES)
         # in this case, PP_RETURN was the third item added, so its id should be 3, not 2
         PP_RETURN['payment_id'] = 3
         # should only be one result, so get the only element of the list
@@ -199,5 +199,5 @@ class TestInterfaceFunctional(unittest.TestCase):
 
     def test_unsuccessful_query(self):
         # try querying for something that doesn't exist
-        result = ps._query_payments(BAD_QUERY_ATTRIBUTES)
+        result = self.ps._query_payments(BAD_QUERY_ATTRIBUTES)
         assert result == []

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -2,7 +2,8 @@
 # python -m unittest discover
 # nosetests -v --rednose --nologcapture
 
-import unittest, mock
+import unittest
+import mock
 
 from app import payments
 from app.db import app_db
@@ -51,8 +52,8 @@ DC_RETURN['payment_id'] = 2
 ps = PaymentService()
 
 QUERY_ATTRIBUTES = {
-    'user_name': 'John Jameson',
-    'card_type': 'Mastercard'
+    'user_id': 2,
+    'nickname': 'my paypal'
 }
 
 class TestInterface(unittest.TestCase):
@@ -147,11 +148,14 @@ class TestInterface(unittest.TestCase):
     def test_interface_query_payments(self, mock_db):
         # this is a long mock - note that the method call chaining matches that of the method call
         # on self.db in _query_payments
-        mock_db.query(Payment).filter_by.return_value = [DEBIT]
+
+        # set the return value of ...filter_by() to a new mock whose all property is a function that
+        # returns [DC_RETURN]; this is done so that when payment_query.all() is called, [DC_RETURN] is returned
+        mock_db.query(Payment).filter_by.return_value = mock.MagicMock(all=lambda: [DC_RETURN])
         result = self.ps._query_payments(QUERY_ATTRIBUTES)
 
         mock_db.query(Payment).filter_by.assert_called_once_with(**QUERY_ATTRIBUTES)
-        self.assertEqual(result, [DEBIT])
+        self.assertEqual(result, [DC_RETURN])
 
     @mock.patch.object(app_db, 'session')
     def test_interface_query_payments_error(self, mock_db):
@@ -161,3 +165,40 @@ class TestInterface(unittest.TestCase):
             result = self.ps._query_payments(QUERY_ATTRIBUTES)
         # also check that the mocked app_db was called appropriately
         mock_db.query(Payment).filter_by.assert_called_once_with(**QUERY_ATTRIBUTES)
+
+
+class TestInterfaceFunctional(unittest.TestCase):
+    """
+    A class for doing more functional tests involving the interface.py classes.
+    Actual db connections are used, so db resources are created and destroyed.
+    """
+
+    def setUp(self):
+        payments.app.debug = True
+        payments.app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://payments:payments@localhost:5432/test'
+        app_db.create_all()  # make our sqlalchemy tables
+
+        payments_to_add = (CREDIT, DEBIT, PAYPAL)
+        for p in payments_to_add:
+            payment = Payment()
+            payment.deserialize(p)
+            app_db.session.add(payment)
+            app_db.session.commit()
+
+        self.ps = ps
+
+    def tearDown(self):
+        app_db.session.remove()
+        app_db.drop_all()
+
+    def test_successful_query(self):
+        # No mocking for this test since we want to test the method's ability to *actually* retrieve resources
+        # the query attributes should match the CREDIT payment item
+
+        result = ps._query_payments(QUERY_ATTRIBUTES)
+        # in this case, PP_RETURN was the third item added, so its id should be 3, not 1
+        PP_RETURN['payment_id'] = 3
+
+        # should only be one result, so get the only element of the list
+        assert result[0].serialize() == PP_RETURN
+

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -2,28 +2,50 @@
 # python -m unittest discover
 # nosetests -v --rednose --nologcapture
 
-import unittest
-#from mock import patch
+import unittest, mock
 from app import payments
 from app.db import app_db
 from app.db.models import Payment, Detail
 from app.db.interface import PaymentService
 from app.error_handlers import DataValidationError
 
+CC_DETAIL = {'user_name' : 'Jimmy Jones', 'card_number' : '1111222233334444',
+             'expires' : '01/2019', 'card_type' : 'Mastercard'}
+
+DC_DETAIL = {'user_name' : 'John Jameson', 'card_number' : '4444333322221111',
+             'expires' : '02/2020', 'card_type' : 'Visa'}
+
+PP_DETAIL = {'user_name' : 'John Jameson', 'user_email' : 'jj@aol.com'}
+
 CREDIT = {'nickname' : 'my credit', 'user_id' : 1, 'payment_type' : 'credit', 
-             'details' : {'user_name' : 'Jimmy Jones', 'card_number' : '1111222233334444',
-             'expires' : '01/2019', 'card_type' : 'Mastercard'}}
+          'details' : CC_DETAIL}
 
 DEBIT = {'nickname' : 'my debit', 'user_id' : 2, 'payment_type' : 'debit', 
-         'details' : {'user_name' : 'John Jameson', 'card_number' : '4444333322221111',
-         'expires' : '02/2020', 'card_type' : 'Visa'}}
+         'details' : DC_DETAIL}
 
 PAYPAL = {'nickname' : 'my paypal', 'user_id' : 2, 'payment_type' : 'paypal', 
-          'details' : {'user_name' : 'John Jameson', 'user_email' : 'jj@aol.com'}}
+          'details' : PP_DETAIL}
 
 #note 'nickname' is spelled wrong
 BAD_DATA = {'nicknam3' : 'my paypal', 'user_id' : 2, 'payment_type' : 'paypal', 
-            'details' : {'user_name' : 'John Jameson', 'user_email' : 'jj@aol.com'}}
+            'details' : PP_DETAIL}
+
+PP_RETURN = dict(PAYPAL)
+PP_RETURN ['is_default'] = False
+PP_RETURN ['charge_history'] = 0.0
+PP_RETURN ['payment_id'] = 1
+PP_RETURN ['details']['is_linked'] = True
+
+CC_RETURN = dict(CREDIT)
+CC_RETURN['is_default'] = False
+CC_RETURN['charge_history'] = 0.0
+CC_RETURN['payment_id'] = 1
+
+#this should always be added second
+DC_RETURN = dict(DEBIT)
+DC_RETURN['is_default'] = False
+DC_RETURN['charge_history'] = 0.0
+DC_RETURN['payment_id'] = 2
 
 ps = PaymentService()
 
@@ -46,7 +68,14 @@ class TestInterface(unittest.TestCase):
         app_db.session.remove()
         app_db.drop_all()
 
-    def test_interface_add_card(self):
+    def test_interface_add_card_returns_json(self):
+        data = DEBIT
+        payment = ps.add_payment(data)
+        self.assertTrue(type(payment), type({}))
+        self.assertTrue(payment['nickname'] == 'my debit')
+        self.assertTrue(payment['details']['user_name'] == 'John Jameson')
+
+    def test_interface_add_card_to_db(self):
         data = DEBIT
         p2 = app_db.session.query(Payment).get(2)
         self.assertEqual(p2, None)
@@ -57,7 +86,7 @@ class TestInterface(unittest.TestCase):
         self.assertEqual(p2.nickname, 'my debit')
         self.assertEqual(d2.user_name, 'John Jameson')
 
-    def test_interface_add_paypal(self):
+    def test_interface_add_paypal_to_db(self):
         data = PAYPAL
         p2 = app_db.session.query(Payment).get(2)
         self.assertEqual(p2, None)
@@ -80,3 +109,30 @@ class TestInterface(unittest.TestCase):
     def test_interface_add_garbage(self):
         garbage = 'afv@#(&@(#Z@#>X@C8rq rq34tr0q934r 9qr@(#*(@!$))'
         self.assertRaises(DataValidationError, ps.add_payment, garbage)
+
+    """ 
+    adding some mock tests in addition to the above since add_payment
+    relies on functions in Payment / Detail
+
+    these also rely on Deserialize methods, but since those reuturn model objects,
+    I'm not sure how to mock those quite yet... will revisit
+    """
+    @mock.patch.object(Detail, 'serialize', return_valie=CC_DETAIL, autospec=True)
+    @mock.patch.object(Payment, 'serialize', return_value=CC_RETURN, autospec=True)
+    def test_interface_add_card_mock(self, mock_serial, mock_det_serial):
+        payment = ps.add_payment(CREDIT)
+        self.assertTrue(type(payment), type({}))
+        self.assertEqual(CC_RETURN, payment)
+        self.assertEqual(CC_DETAIL, payment['details'])
+
+    @mock.patch.object(Detail, 'serialize', autospec=True)
+    @mock.patch.object(Payment, 'serialize', return_value=PP_RETURN, autospec=True)
+    def test_interface_add_paypal_mock(self, mock_pay_serial, mock_det_serial):
+        temp = dict(PP_DETAIL)
+        temp['is_linked'] = True
+        mock_det_serial.return_value = temp
+        payment = ps.add_payment(PAYPAL)
+        self.assertTrue(type(payment), type({}))
+        self.assertEqual(PP_RETURN, payment)
+        self.assertEqual(temp, payment['details'])
+


### PR DESCRIPTION
***NOTE: DO NOT MERGE UNTIL #116 IS MERGED***

This PR adds a private query method to the PaymentService so that it can easily retrieve relevant payment items based on desired attributes.  Unit tests are included; they make use of mocking the `app_db` object, which in turn mocks the connection to the database.

The note above about not merging is there because my branch has been rebased on top of #116, so it would be best for this branch to get merged after that one is merged.  Once #116 is merged, the changes that branch introduces will disappear from the changes it *appears* this branch is making.

So, in order to review what this branch actually adds:
* app/db/interface.py -> _query_payments method
* tests/test_interface.py -> the last two test cases