### PR TITLE
hotfix to the hotfix (bluemix db connect)

### DIFF
--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -2,15 +2,12 @@ from flask_sqlalchemy import SQLAlchemy
 
 from app import app
 
-'''
-db connection string current in config, but will implement a way to get from environ
-'''
 
 app_db = SQLAlchemy(app)
 
 '''
 most import models AFTER db init
-but before table creation
+but BEFORE table creation
 '''
 from app.db import models
 

--- a/config.py
+++ b/config.py
@@ -1,10 +1,5 @@
 import os, sys
 
-'''
-for local db, need to EXPORT env variable after vagrant ssh:
-export LOCAL_DB = postgresql://payments:payments@localhost:5432/dev
-'''
-
 if 'VCAP_SERVICES' in os.environ:
     VCAP_SERVICES = os.environ['VCAP_SERVICES']
     services = json.loads(VCAP_SERVICES)

--- a/config.py
+++ b/config.py
@@ -1,2 +1,21 @@
-SQLALCHEMY_DATABASE_URI = 'postgresql://payments:payments@localhost:5432/dev'
+import os, sys
+
+'''
+for local db, need to EXPORT env variable after vagrant ssh:
+export LOCAL_DB = postgresql://payments:payments@localhost:5432/dev
+'''
+
+if 'VCAP_SERVICES' in os.environ:
+    VCAP_SERVICES = os.environ['VCAP_SERVICES']
+    services = json.loads(VCAP_SERVICES)
+    creds = services['elephantsql'][0]['credentials']
+    SQLALCHEMY_DATABASE_URI = creds['uri']
+    print 'Connecting to Bluemix postgres db...'
+elif 'LOCAL_DB' in os.environ:
+    SQLALCHEMY_DATABASE_URI = os.environ['LOCAL_DB']
+    print 'Connecting to local postgres db...'
+else:
+    print "Missing database config. Exiting..."
+    sys.exit(1)
+
 SQLALCHEMY_TRACK_MODIFICATIONS = False


### PR DESCRIPTION
added credentials for bluemix db connect. if no bluemix, then tries local. if not local, app exits

so the local connect still works, but don't have a way to test the bluemix bit. based this on the redis example from class, but used the credentials for our postgres db service on bluemix, which is called 'elephantsql'

unless anyone has any thoughts or opinions, let's push this out and see what happens?

EDIT: please note, for this to work with local DBs, you need to export the connection string in terminal after you `vagrant ssh`. 

```
export LOCAL_DB = postgresql://payments:payments@localhost:5432/dev
```