### PR TITLE
Write bdd feature for delete

### DIFF
--- a/tests/features/payments.feature
+++ b/tests/features/payments.feature
@@ -58,7 +58,8 @@ Scenario: Set default payment
 
 Scenario: Delete an existing payment
     When I make a delete request to "/payments/1"
-    Then I should see "Not Found" when making a get request "/payments/1"
     Then I should be returned nothing
     When I attempt to retrieve the deleted item "/payments/1"
     Then I should see a HTTP_404_NOT_FOUND response
+    When I try to delete a non-existent payment at "/payments/100"
+    Then I should be returned a HTTP_404_NOT_FOUND response

--- a/tests/features/payments.feature
+++ b/tests/features/payments.feature
@@ -57,9 +57,9 @@ Scenario: Set default payment
     Then user with id "1" should see payment with id "1" set as default
 
 Scenario: Delete an existing payment
-    When I make a delete request to "/payments/1"
+    When I try to delete payment 1
     Then I should be returned nothing
-    When I attempt to retrieve the deleted item "/payments/1"
-    Then I should see a HTTP_404_NOT_FOUND response
-    When I try to delete a non-existent payment at "/payments/100"
-    Then I should be returned a HTTP_204_NO_CONTENT response
+    When I attempt to retrieve the deleted payment 1
+    Then the server should tell me it was not found
+    When I try to delete a non-existent payment
+    Then I should be returned nothing

--- a/tests/features/payments.feature
+++ b/tests/features/payments.feature
@@ -59,3 +59,6 @@ Scenario: Set default payment
 Scenario: Delete an existing payment
     When I make a delete request to "/payments/1"
     Then I should see "Not Found" when making a get request "/payments/1"
+    Then I should be returned nothing
+    When I attempt to retrieve the deleted item "/payments/1"
+    Then I should see a HTTP_404_NOT_FOUND response

--- a/tests/features/payments.feature
+++ b/tests/features/payments.feature
@@ -58,8 +58,8 @@ Scenario: Set default payment
 
 Scenario: Delete an existing payment
     When I try to delete payment 1
-    Then I should be returned nothing
+    Then I should be returned nothing for payment 1
     When I attempt to retrieve the deleted payment 1
-    Then the server should tell me it was not found
-    When I try to delete a non-existent payment
-    Then I should be returned nothing
+    Then the server should tell me payment 1 was not found
+    When I try to delete a non-existent payment with id 100
+    Then I should be returned nothing for payment 100

--- a/tests/features/payments.feature
+++ b/tests/features/payments.feature
@@ -62,4 +62,4 @@ Scenario: Delete an existing payment
     When I attempt to retrieve the deleted item "/payments/1"
     Then I should see a HTTP_404_NOT_FOUND response
     When I try to delete a non-existent payment at "/payments/100"
-    Then I should be returned a HTTP_404_NOT_FOUND response
+    Then I should be returned a HTTP_204_NO_CONTENT response

--- a/tests/features/payments.feature
+++ b/tests/features/payments.feature
@@ -55,3 +55,7 @@ Scenario: Set default payment
     And user with id "1" performs "set-default" on "payments" with id "1"
     When I get "payments" with id "1"
     Then user with id "1" should see payment with id "1" set as default
+
+Scenario: Delete an existing payment
+    When I make a delete request to "/payments/1"
+    Then I should see "Not Found" when making a get request "/payments/1"

--- a/tests/features/steps/payment_steps.py
+++ b/tests/features/steps/payment_steps.py
@@ -135,6 +135,12 @@ def step_impl(context, url):
 def step_impl(context, url):
     context.resp = context.app.get(url)
 
+
+@when('I try to delete a non-existent payment at "{url}"')
+def step_impl(context, url):
+    context.resp = context.app.delete(url)
+
+
 ###########
 # T H E N #
 ###########
@@ -171,6 +177,11 @@ def step_impl(context, http_code):
     desired_http_code = getattr(status, http_code)
     assert context.resp.status_code == desired_http_code
 
+
+@then('I should be returned a {http_code} response')
+def step_impl(context, http_code):
+    desired_http_code = getattr(status, http_code)
+    assert context.resp.status_code == desired_http_code
 
 '''
 

--- a/tests/features/steps/payment_steps.py
+++ b/tests/features/steps/payment_steps.py
@@ -129,7 +129,11 @@ def step_impl(context, u_id, action, url, p_id):
 @when('I make a delete request to "{url}"')
 def step_impl(context, url):
     context.resp = context.app.delete(url)
-    assert context.resp.status_code == status.HTTP_204_NO_CONTENT
+
+
+@when('I attempt to retrieve the deleted item "{url}"')
+def step_impl(context, url):
+    context.resp = context.app.get(url)
 
 ###########
 # T H E N #
@@ -156,10 +160,16 @@ def step_impl(context, u_id, p_id):
     assert payments[0]['payment_id'] == int(p_id)
     assert payments[0]['user_id'] == int(u_id)
 
-@then('I should see "{message}" when making a get request to "{url}"')
-def step_impl(context, message, url):
-    new_response = context.app.get(url)
-    assert new_response.resp.status_code == status.HTTP_404_NOT_FOUND
+@then('I should be returned nothing')
+def step_impl(context):
+    assert context.resp.status_code == status.HTTP_204_NO_CONTENT
+    assert context.resp.data == ''
+
+
+@then('I should see a {http_code} response')
+def step_impl(context, http_code):
+    desired_http_code = getattr(status, http_code)
+    assert context.resp.status_code == desired_http_code
 
 
 '''

--- a/tests/features/steps/payment_steps.py
+++ b/tests/features/steps/payment_steps.py
@@ -3,6 +3,7 @@ from flask_api import status
 from app.db.interface import PaymentService
 import json
 
+
 #############
 # G I V E N #
 #############
@@ -82,6 +83,7 @@ def step_impl(context, url, id):
 def step_impl(context):
     context.resp = context.app.get('/')
 
+'''
 @when(u'I add a new payment to "{url}"')
 def step_impl(context, url):
     context.resp = context.app.post(url, data=context.resp.data, content_type='application/json')
@@ -119,6 +121,15 @@ def step_impl(context, u_id, action, url, p_id):
     context.resp = context.app.patch(target, data=data, content_type='application/json')
     assert context.resp.status_code == status.HTTP_200_OK
     assert 'Payment with id: 1 set as default' in context.resp.data
+	context.resp = context.app.post(url, data=context.resp.data, content_type='application/json')
+	assert context.resp.status_code == status.HTTP_201_CREATED
+'''
+
+
+@when('I make a delete request to "{url}"')
+def step_impl(context, url):
+    context.resp = context.app.delete(url)
+    assert context.resp.status_code == status.HTTP_204_NO_CONTENT
 
 ###########
 # T H E N #
@@ -144,6 +155,11 @@ def step_impl(context, u_id, p_id):
     assert payments[0]['is_default'] == True
     assert payments[0]['payment_id'] == int(p_id)
     assert payments[0]['user_id'] == int(u_id)
+
+@then('I should see "{message}" when making a get request to "{url}"')
+def step_impl(context, message, url):
+    new_response = context.app.get(url)
+    assert new_response.resp.status_code == status.HTTP_404_NOT_FOUND
 
 
 '''

--- a/tests/features/steps/payment_steps.py
+++ b/tests/features/steps/payment_steps.py
@@ -139,8 +139,9 @@ def step_impl(context, id):
     context.resp = context.app.get(url)
 
 
-@when('I try to delete a non-existent payment')
-def step_impl(context, url):
+@when('I try to delete a non-existent payment with id {id}')
+def step_impl(context, id):
+    url = '/payments/{}'.format(id)
     context.resp = context.app.delete(url)
 
 
@@ -169,16 +170,19 @@ def step_impl(context, u_id, p_id):
     assert payments[0]['payment_id'] == int(p_id)
     assert payments[0]['user_id'] == int(u_id)
 
-@then('I should be returned nothing')
-def step_impl(context):
+@then('I should be returned nothing for payment {id}')
+def step_impl(context, id):
     assert context.resp.status_code == status.HTTP_204_NO_CONTENT
     assert context.resp.data == ''
 
 
-@then('the server should tell me it was not found')
-def step_impl(context):
+@then('the server should tell me payment {id} was not found')
+def step_impl(context, id):
+    expected_response = payments.NOT_FOUND_ERROR_BODY
+    expected_response['error'].format(id)
+    actual_response = json.loads(context.resp.data)
     assert context.resp.status_code == status.HTTP_404_NOT_FOUND
-    assert context.resp.data == payments.NOT_FOUND_ERROR_BODY
+    assert actual_response == expected_response
 
 '''
 

--- a/tests/features/steps/payment_steps.py
+++ b/tests/features/steps/payment_steps.py
@@ -1,6 +1,7 @@
 from behave import given, when, then
 from flask_api import status
 from app.db.interface import PaymentService
+from app import payments
 import json
 
 
@@ -126,17 +127,19 @@ def step_impl(context, u_id, action, url, p_id):
 '''
 
 
-@when('I make a delete request to "{url}"')
-def step_impl(context, url):
+@when('I try to delete payment {id}')
+def step_impl(context, id):
+    url = '/payments/{}'.format(id)
     context.resp = context.app.delete(url)
 
 
-@when('I attempt to retrieve the deleted item "{url}"')
-def step_impl(context, url):
+@when('I attempt to retrieve the deleted payment {id}')
+def step_impl(context, id):
+    url = '/payments/{}'.format(id)
     context.resp = context.app.get(url)
 
 
-@when('I try to delete a non-existent payment at "{url}"')
+@when('I try to delete a non-existent payment')
 def step_impl(context, url):
     context.resp = context.app.delete(url)
 
@@ -172,16 +175,10 @@ def step_impl(context):
     assert context.resp.data == ''
 
 
-@then('I should see a {http_code} response')
-def step_impl(context, http_code):
-    desired_http_code = getattr(status, http_code)
-    assert context.resp.status_code == desired_http_code
-
-
-@then('I should be returned a {http_code} response')
-def step_impl(context, http_code):
-    desired_http_code = getattr(status, http_code)
-    assert context.resp.status_code == desired_http_code
+@then('the server should tell me it was not found')
+def step_impl(context):
+    assert context.resp.status_code == status.HTTP_404_NOT_FOUND
+    assert context.resp.data == payments.NOT_FOUND_ERROR_BODY
 
 '''
 


### PR DESCRIPTION
This PR adds basic BDD coverage for what should happen in the event of a delete.

First we ensure that the delete works correctly.
Second we check that trying to retrieve the deleted resource results in a 404.

**NOTE**: Until the empty payments list catch fix is properly implemented, the one test for a 404 will fail.