### PR TITLE
fix get return and query - merge this before #159 & #161

### DIFF
--- a/app/db/interface.py
+++ b/app/db/interface.py
@@ -128,10 +128,10 @@ class PaymentService(object):
         else:
             payments = self.db.session.query(Payment).all()
 
-        if payments:
-            payments = self._remove_soft_deletes(payments)
-        else:
-            raise DataValidationError
+        payments = self._remove_soft_deletes(payments)
+
+        if not payments:
+            raise PaymentNotFoundError
 
         return [payment.serialize() for payment in payments]
 

--- a/app/payments.py
+++ b/app/payments.py
@@ -60,6 +60,8 @@ def list_payments():
             # this cast allows us to make a simple dictionary where each query param is a key and the
             # value is a list that contains the value(s) of that query parameter
             request_args = dict(request_args)
+            for key in request_args:
+                request_args[key] = request_args[key][0]
             results = payment_service.get_payments(payment_attributes=request_args)
 
         else:

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -89,9 +89,8 @@ class TestInterface(unittest.TestCase):
         id = [99]
 
         mock_db.query(Payment).filter.return_value.all.return_value = []
-        with self.assertRaises(DataValidationError) as e:
+        with self.assertRaises(PaymentNotFoundError):
             result = self.ps.get_payments(payment_ids=id)
-            self.assertTrue('id 99 could not be found' in e)
         mock_db.query(Payment).filter.assert_called_once()
         mock_P.serialize.assert_not_called()
 
@@ -196,9 +195,8 @@ class TestInterface(unittest.TestCase):
     def test_interface_get_missing_payment(self):
         id = [99]
 
-        with self.assertRaises(DataValidationError) as e:
+        with self.assertRaises(PaymentNotFoundError):
             result = self.ps.get_payments(payment_ids=id)
-            self.assertTrue('id 99 could not be found' in e)
 
     def test_interface_get_three_consec_payment(self):
         ids = [1,2,3]
@@ -435,8 +433,8 @@ class TestInterface(unittest.TestCase):
         self.assertIsNotNone(deleted_payment)
         self.assertTrue(deleted_payment.is_removed)
 
-        current_payments = self.ps.get_payments()
-        self.assertEqual(len(current_payments),0)
+        with self.assertRaises(PaymentNotFoundError):
+            current_payments = self.ps.get_payments()
 
     def test_interface_delete_payment_with_invalid_id(self):
         #setUp has one item in the DB

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -164,7 +164,7 @@ class TestPaymentsCRUD(unittest.TestCase):
         # return payments that have a specific attribute
         specific_attribute = 'payment_type'
         specific_attribute_value = 'paypal'
-        attribute_params = {'payment_type': ['paypal']}
+        attribute_params = {'payment_type': 'paypal'}
         paypal_payment = SAMPLE_PAYMENTS[1]
 
         with patch.object(PaymentService, 'get_payments', return_value=paypal_payment) as mocked_service:


### PR DESCRIPTION
this should be merged in before #159 and #161 

in response to #161 , a fix was applied to make deletes throw proper errors, but this broke add/create bdd features. the issue stemmed from the result returned by interface get. this fix throws 404 error if payments is [] AFTER removeing soft-deletes

updated tests accordingly

EDIT: while working on set-default bdd feature, I encountered another bug w/r/t the query. it was quick fix so I'm adding it here so everyone can get the fix fast.

the problem was this: after casting request_args to dict, the values get thrown into a list. the db query on the interface level didn't like this so after the cast in payments.py, i ran the dict through a loop and pulled out each element and place it back into the dict as just non-list object. this seemed to do the trick.

also updated tests accordingly