### PR TITLE
trying new bluemix requirements sans psycopg2

### DIFF
--- a/bluemix-requirements.txt
+++ b/bluemix-requirements.txt
@@ -1,0 +1,18 @@
+Flask==0.12
+Flask-API==0.6.9
+Flask-SQLAlchemy==2.1
+Flask-Migrate==1.8.0
+alembic==0.9.1
+SQLAlchemy==1.1.5
+# Testing
+httpie==0.9.9
+nose==1.3.7
+rednose==1.2.1
+pinocchio==0.4.2
+mock
+# Code coverage
+coverage==4.2
+codecov==2.0.5
+# BDD
+behave==1.2.5
+selenium==3.3.1


### PR DESCRIPTION
trying one last thing before giving up for a little bit.

logs in BM indicate issues installing psycopg2. my assumption here is we won't need psycopg2 since we should be testing against the database services bound to bluemix app.

whether or not it finds those services is another question, but hoping to at least get past dependency installation with this fix.

only addition is a separate requirements file which gets referenced in BM test job so should have no effect on anything else.