### PR TITLE
updated manifest for two bluemix apps

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -7,3 +7,11 @@ applications:
   host: nyu-devops-sp17-payments
   disk_quota: 1024M
   buildpack: python_buildpack
+- path: .
+  memory: 64M
+  instances: 1
+  domain: mybluemix.net
+  name: nyu-devops-sp17-payments-dev
+  host: nyu-devops-sp17-payments-dev
+  disk_quota: 1024M
+  buildpack: python_buildpack


### PR DESCRIPTION
this branch is poorly named as it started out with one intention, but another arose.

while trying to figure out how to get multiple DB services running in an app (and it doesnt seem possible with the free version we're using), I decided to try and setup the rest of the pipeline so we could have a dedicated test and prod db on bluemix.

that's what this update to the manifest is for 