### PR TITLE
Refactor update valid

### DIFF
--- a/app/db/interface.py
+++ b/app/db/interface.py
@@ -156,7 +156,10 @@ class PaymentService(object):
         except exc.SQLAlchemyError:
             raise PaymentServiceQueryError('Could not retrieve payment items due to query error with given attributes')
 
-# UTILITY FUNCTIONS
+#######################
+## UTILITY FUNCTIONS ##
+#######################
+
     def is_valid(self, new_payment):
         valid = False
 
@@ -168,16 +171,20 @@ class PaymentService(object):
         user_name = new_payment['details']['user_name']
 
         if bool(re.match("^[A-Za-z\-' ]{0,50}$", user_name)):
-            print user_name
+            
             if payment_type == 'credit' or payment_type == 'debit':
                 card_number = new_payment['details']['card_number']
                 card_type = new_payment['details']['card_type']
                 expires = new_payment['details']['expires']
+                
                 if bool(re.match('^[0-9]{16}$', card_number)):
+                    
                     if bool(re.match("^[A-Za-z ]{0,10}$", card_type)):
+                        
                         if bool(re.match('^[0-9]{2}/[0-9]{4}$', expires)):
                             month = int(expires[:2])
                             year = int(expires[3:])
+                            
                             if year > datetime.now().year:
                                 valid = True
                             elif year == datetime.now().year and month >= datetime.now().month:
@@ -185,7 +192,9 @@ class PaymentService(object):
 
             elif payment_type == 'paypal':
                 user_email = new_payment['details']['user_email']
+                
                 if bool(re.match('^[\W\w]+@[\W\w]+\.[A-Za-z]{2,3}$', user_email)):
+                    
                     if new_payment['details']['is_linked']:
                         valid = True
 

--- a/app/db/interface.py
+++ b/app/db/interface.py
@@ -162,8 +162,11 @@ class PaymentService(object):
 ## UTILITY FUNCTIONS ##
 #######################
 
-    def is_valid(self, new_payment):
+    def is_valid(self, new_payment, user_id=None):
         valid = False
+
+        if new_payment['user_id'] != user_id:
+            raise DataValidationError('Error: You cannot modify the field: user_id')
 
         for key in self.NONUPDATABLE_PAYMENT_FIELDS :
             if key in new_payment:

--- a/app/db/interface.py
+++ b/app/db/interface.py
@@ -27,12 +27,14 @@ class PaymentService(object):
 
         :param payment_data: <dict> a validated JSON payload that describes a new Payment object
         """
+
         p = Payment()
 
         try:
             p.deserialize(payment_data)
         except DataValidationError as e:
             raise DataValidationError(e.message)
+
         self.db.session.add(p)
         self.db.session.commit()
         return p.serialize()
@@ -194,9 +196,7 @@ class PaymentService(object):
                 user_email = new_payment['details']['user_email']
                 
                 if bool(re.match('^[\W\w]+@[\W\w]+\.[A-Za-z]{2,3}$', user_email)):
-                    
-                    if new_payment['details']['is_linked']:
-                        valid = True
+                    valid = True
 
         return valid
 

--- a/app/db/interface.py
+++ b/app/db/interface.py
@@ -84,7 +84,7 @@ class PaymentService(object):
             raise PaymentNotFoundError('Invalid payment: Payment ID not found')
         if payment_replacement:
             # TODO 	: test cases for validity in next sprint
-            if not self.is_valid(payment_replacement):
+            if not self.is_valid(payment_replacement, payment.user_id):
                 raise DataValidationError('Invalid payment: body of request contained bad or no data')
             payment.deserialize(payment_replacement)
         elif payment_attributes: #patch
@@ -165,7 +165,7 @@ class PaymentService(object):
     def is_valid(self, new_payment, user_id=None):
         valid = False
 
-        if new_payment['user_id'] != user_id:
+        if user_id and int(new_payment['user_id']) != user_id:
             raise DataValidationError('Error: You cannot modify the field: user_id')
 
         for key in self.NONUPDATABLE_PAYMENT_FIELDS :

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -59,23 +59,6 @@ class Payment(app_db.Model):
         except TypeError as e:
             raise DataValidationError('Invalid payment: body of request contained bad or no data')
 
-    def deserialize_put(self, data):
-        try:
-            self.user_id = data['user_id']
-            self.nickname = data['nickname']
-            self.payment_type = data['payment_type']
-            details = data['details']
-            d = Detail()
-            if (self.payment_type == 'credit' or self.payment_type == 'debit'):
-                d.deserialize_card(details)
-            else:
-                d.deserialize_paypal(details)
-            self.details = d
-        except KeyError as e:
-            raise DataValidationError('Invalid payment: missing ' + e.args[0])
-        except TypeError as e:
-            raise DataValidationError('Invalid payment: body of request contained bad or no data')
-
 class Detail(app_db.Model):
     __tablename__ = 'detail'
     id = app_db.Column(app_db.Integer, primary_key=True)

--- a/tests/features/payments.feature
+++ b/tests/features/payments.feature
@@ -62,7 +62,7 @@ Scenario: Update a payment with illegal data (PUT)
         | nickname  | user_id | payment_type | user_name   | expires | card_type | card_number      | is_removed |
         | cashmoney | 1       | credit       | Jimmy Jones | 08/2018 | Visa      | 4444333322221111 | True       |
     When I put "payments" with id "1"
-    Then I should see "body of request contained bad or no data" with status code "400"
+    Then I should see "You cannot modify the field: is_removed" with status code "400"
 
 Scenario: Set default payment
     When user with id "1" has existing "payments"

--- a/tests/features/steps/payment_steps.py
+++ b/tests/features/steps/payment_steps.py
@@ -172,13 +172,12 @@ def step_impl(context, id):
 
 @then('I should see "{message}" with status code "{code}"')
 def step_impl(context, message, code):
-    print(context.resp.status_code)
+    print(context.resp.data)
     assert message in context.resp.data
     assert context.resp.status_code == int(code)
 
 @then('I should see "{message}"')
 def step_impl(context, message):
-    print(context.resp.data)
     assert message in context.resp.data
 
 @then('I should see a payment with id "{id}" and "{attribute}" = "{value}"')

--- a/tests/features/steps/payment_steps.py
+++ b/tests/features/steps/payment_steps.py
@@ -172,7 +172,6 @@ def step_impl(context, id):
 
 @then('I should see "{message}" with status code "{code}"')
 def step_impl(context, message, code):
-    print(context.resp.data)
     assert message in context.resp.data
     assert context.resp.status_code == int(code)
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -849,6 +849,14 @@ class TestInterface(unittest.TestCase):
             result = self.ps.is_valid(illegal)
         self.assertTrue('cannot modify the field: is_removed' in e.exception.message)
 
+    def test_interface_util_is_valid_illegal_update(self):
+        illegal = copy.deepcopy(CREDIT)
+        user_id = illegal['user_id']
+        illegal['user_id'] = 99
+        with self.assertRaises(DataValidationError) as e:
+            result = self.ps.is_valid(illegal, user_id)
+        self.assertTrue('cannot modify the field: user_id' in e.exception.message)
+
     def test_interface_util_is_valid_good_expires(self):
         good = copy.deepcopy(CREDIT)
         good['details']['expires'] = '02/2020'

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -903,12 +903,6 @@ class TestInterface(unittest.TestCase):
         result = self.ps.is_valid(good)
         self.assertTrue(result)
 
-    def test_interface_util_is_valid_bad_link(self):
-        bad = copy.deepcopy(PAYPAL)
-        bad['details']['is_linked'] = False
-        result = self.ps.is_valid(bad)
-        self.assertFalse(result)
-
 class TestInterfaceFunctional(unittest.TestCase):
     """
     A class for doing more functional tests involving the interface.py classes.

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -842,6 +842,22 @@ class TestInterface(unittest.TestCase):
         result = self.ps.is_valid(bad)
         self.assertFalse(result)
 
+    def test_interface_util_is_valid_illegal_update(self):
+        illegal = copy.deepcopy(CREDIT)
+        illegal['is_removed'] = True
+        with self.assertRaises(DataValidationError) as e:
+            result = self.ps.is_valid(illegal)
+        self.assertTrue('cannot modify the field: is_removed' in e.exception.message)
+
+    def test_interface_util_is_valid_good_expires(self):
+        good = copy.deepcopy(CREDIT)
+        good['details']['expires'] = '02/2020'
+        result = self.ps.is_valid(good)
+        self.assertTrue(result)
+        good['details']['expires'] = '11/2017'  #this test will fail in december 2017
+        result = self.ps.is_valid(good)
+        self.assertTrue(result)
+
     def test_interface_util_is_valid_bad_expires(self):
         bad = copy.deepcopy(CREDIT)
         bad['details']['expires'] = 'whatever'
@@ -925,9 +941,6 @@ class TestInterfaceFunctional(unittest.TestCase):
         result = self.ps._query_payments(QUERY_ATTRIBUTES)
         # in this case, PP_RETURN was the third item added, so its id should be 3, not 2
         PP_RETURN['payment_id'] = 3
-        print result[0].serialize()
-        print '---'
-        print PP_RETURN
         # should only be one result, so get the only element of the list
         assert result[0].serialize() == PP_RETURN
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -174,26 +174,3 @@ class TestModels(unittest.TestCase):
         mock_detail_serial.assert_called_once()
         payment['payment_id'] = 2
         self.assertEqual(payment, DC_RETURN)
-    
-    def test_payment_deserialize_put(self):
-        p = Payment()
-        p.deserialize(PUT_CREDIT)
-        p.deserialize_put(PUT_CREDIT_IP)
-        self.assertEqual(p.nickname, 'favcredit')
-        self.assertEqual(p.user_id, 1)
-        self.assertEqual(p.payment_type, 'credit')
-        self.assertEqual(p.details.serialize(), CC_DETAIL)
-        self.assertEqual(p.is_default, False)
-        self.assertEqual(p.is_removed, False)
-        self.assertEqual(p.charge_history, 0.0)
-    
-    def test_detail_deserialize_put_paypal(self):
-        p = Payment()
-        p.deserialize_put(PP_RETURN)
-        self.assertEqual(p.details.serialize(), PP_DETAIL)
-    
-    def test_payment_deserialize_bad_data(self):
-        p = Payment();
-        self.assertRaises(DataValidationError, p.deserialize_put, BAD_DATA)
-        self.assertRaises(DataValidationError, p.deserialize_put, BAD_DATA2)
-        self.assertRaises(DataValidationError, p.deserialize_put, 'as@Q#$*)&2r923rz3ru3892')


### PR DESCRIPTION
added some functionality to is_valid and added test coverage

checks within each type (card or paypal) are chained and only pass if all pass.

username/card_type : ensures only alphabet or select special characters are used
card-number : ensures only numbers at len = 16
expires : ensures mm/yyyy format and new card being passed is not currently expired
user_email : ensures email is in valid format (but not necessarily a valid email)