### PR TITLE
Dockerfile fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,22 @@
 # Start with a Linux micro-container to keep the image tiny
 FROM alpine:3.3
 
-# Install just the Python runtime (no dev)
+# Install python and dependencies
 RUN apk add --update \
-    python \
+	python-dev \
     py-pip \
-    py-gdbm \
     postgresql-dev \ 
-    python-dev \
     gcc \ 
     musl-dev \
  && rm -rf /var/cache/apk/*
- #RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/main py-psycopg2
 
 # Expose any ports the app is expecting in the environment
 ENV PORT 5000
 EXPOSE $PORT
+
+# Get connection string from build-args
+ARG URI
+ENV LOCAL_DB=$URI
 
 # Set up a working folder and install the pre-reqs
 WORKDIR /payments

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,20 +5,27 @@ FROM alpine:3.3
 RUN apk add --update \
     python \
     py-pip \
+    py-gdbm \
+    postgresql-dev \ 
+    python-dev \
+    gcc \ 
+    musl-dev \
  && rm -rf /var/cache/apk/*
+ #RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/main py-psycopg2
 
 # Expose any ports the app is expecting in the environment
 ENV PORT 5000
 EXPOSE $PORT
 
 # Set up a working folder and install the pre-reqs
-WORKDIR /app
-ADD requirements.txt /app
+WORKDIR /payments
+ADD requirements.txt /payments
 RUN pip install -r requirements.txt
 
 # Add the code as the last Docker layer because it changes the most
-ADD app/* /app
-ADD run.py /app
+ADD app /payments/app
+ADD run.py /payments
+ADD config.py /payments
 
 # Run the service
 CMD [ "python", "run.py" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,3 +6,12 @@ payments-database:
     - "5432:5432"
   volumes:
     - /var/lib/postgresql/data
+
+payments:
+  build: .
+  restart: always
+  hostname: payments
+  ports:
+    - "5000:5000"
+  links:
+    - payments-database

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,3 @@ coverage==4.2
 codecov==2.0.5
 # BDD
 behave==1.2.5
-selenium==3.3.1


### PR DESCRIPTION
@jdgumz this fixes dockerfile in your PR. can be merged in to your branch if looks good.

all of the extra install in dockerfile is to make psycopg2 work. feels a bit bloated, but couldn't get it working otherwise.

don't have the app running yet, but the container gets built properly from the dockerfile. last run produced this error. haven't dug into it yet. any thoughts?

```
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
could not connect to server: Network unreachable
	Is the server running on host "localhost" (::1) and accepting
	TCP/IP connections on port 5432?
```


Errors aside, here's the current build command:
`docker build --build-arg URI=$LOCAL_DB -t payments .`

don't have a better way to add in local_db env var yet, but this seems to work for now, assuming the above error is fixed. i suspect the db connection isnt reached fast enough during the link process before pyscop tries to access. ive got a fix in mind