### PR TITLE
Make changes to vagrantfile so that local dev creds exist there

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,6 @@ Now let's get started:
 ```
 git clone https://github.com/devops-s17-payments/payments
 cd payments
-```
-
-If you haven't already exported the env variables, execute the following command before vagrant up
-```
-export DB_USER=payments && export DB_PASSWORD=payments && export DB_NAME=dev &&
-export LOCAL_DB=postgresql://payments:payments@payments-database:5432/dev
-```
-
-Now execute these commands to get the vagrant up and running
-
-```
 vagrant up
 vagrant ssh
 cd /vagrant

--- a/README.md
+++ b/README.md
@@ -17,15 +17,6 @@ http://nyu-devops-sp17-payments.mybluemix.net/apidocs/index.html
 
 First, you need some tools. Download [VirtualBox](https://www.virtualbox.org/ "VirtualBox") and [Vagrant](https://www.vagrantup.com/ "Vagrant")
 
-We need to export some environment variables *on your machine* so the Docker Container can use them to create the database:
-
-```
-export DB_USER=payments
-export DB_PASSWORD=payments
-export DB_NAME=dev
-export LOCAL_DB=postgresql://payments:payments@payments-database:5432/dev
-```
-
 Now let's get started:
 
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,7 +67,7 @@ Vagrant.configure(2) do |config|
   ######################################################################
   # Prepare PostgreSQL provisioning - make needed directories and export LOCAL_DB env variable
   config.vm.provision "shell", path: "vagrant_db_provision.sh", 
-    env: {"DB_NAME" => ENV["DB_NAME"], "DB_USER" => ENV["DB_USER"], "DB_PASSWORD" => ENV["DB_PASSWORD"]}
+    env: {"DB_NAME" => "dev", "DB_USER" => "payments", "DB_PASSWORD" => "payments"}
 
   # Add the dev PostgreSQL docker container
   # Note: the "d" essentially refers to the "docker" CLI command
@@ -83,9 +83,9 @@ Vagrant.configure(2) do |config|
   # the vagrant VM's .profile
   config.vm.provision :docker_compose, yml: "/vagrant/docker-compose.yaml", rebuild: true, run: "always",
     env: {
-      "DB_NAME" => ENV["DB_NAME"],
-      "DB_USER" => ENV["DB_USER"],
-      "DB_PASSWORD" => ENV["DB_PASSWORD"],
-      "LOCAL_DB" => ENV["LOCAL_DB"]
+      "DB_NAME" => "dev",
+      "DB_USER" => "payments",
+      "DB_PASSWORD" => "payments",
+      "LOCAL_DB" => "postgresql://payments:payments@payments-database:5432/dev" 
     }
 end

--- a/check_db.py
+++ b/check_db.py
@@ -1,25 +1,27 @@
-import socket
-import time
-import argparse
+import socket, time, arparse, os
 """ Check if port is open, avoid docker-compose race condition """
 
-parser = argparse.ArgumentParser(description='Check if port is open')
-parser.add_argument('--ip', required=True)
-parser.add_argument('--port', required=True)
 
-args = parser.parse_args()
+if 'VCAP_SERVICES' in os.environ:
+	print("Using Bluemix storage service!")
+else:
+	parser = argparse.ArgumentParser(description='Check if port is open')
+	parser.add_argument('--ip', required=True)
+	parser.add_argument('--port', required=True)
 
-# Get arguments
-port = int(args.port)
-ip = str(args.ip)
+	args = parser.parse_args()
 
-# Infinite loop
-while True:
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    result = sock.connect_ex((ip, port))
-    if result == 0:
-        print("{0} port is open!".format(ip))
-        break
-    else:
-        print("{0} port is not open! Checking again soon,".format(ip))
-        time.sleep(3)
+	# Get arguments
+	port = int(args.port)
+	ip = str(args.ip)
+
+	# Infinite loop
+	while True:
+	    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+	    result = sock.connect_ex((ip, port))
+	    if result == 0:
+	        print("{0} port is open!".format(ip))
+	        break
+	    else:
+	        print("{0} port is not open! Checking again soon,".format(ip))
+	        time.sleep(3)


### PR DESCRIPTION
Explicitly places the local dev variables into the Vagrantfile so that there's no need to `export` anything before running `vagrant up` or `vagrant reload --provision`.